### PR TITLE
Splash below menu

### DIFF
--- a/src/worker/src/components/blog-list-layout.tsx
+++ b/src/worker/src/components/blog-list-layout.tsx
@@ -2,11 +2,13 @@ import { raw } from 'hono/html'
 import { type FC } from 'hono/jsx'
 import { type DirData } from '../types'
 import { Menu } from './menu'
+import { Splash } from './splash'
 
 export const BlogListLayout: FC = ({ page, site }) => {
   return (
     <>
       <Menu site={site} />
+      <Splash page={page} />
       {raw(page.html)}
       <ul>
         {page?.dir?.map((dirPage: DirData) => {

--- a/src/worker/src/components/blog-post-layout.tsx
+++ b/src/worker/src/components/blog-post-layout.tsx
@@ -19,15 +19,15 @@ export const BlogPostLayout: FC = ({ page, site, dirEntry }) => {
     <>
       <Menu site={site} />
       <Splash page={page} />
-      <p class="text-gray-400 flex">
+      <p class="flex text-gray-400 hover:text-current">
         <span class="flex-grow">{longdate}</span>
         {dirEntry?.nextPath ? (
         <a
-          class="text-gray-400 hover:text-current no-underline px-4"
+          class="px-4"
           href={dirEntry.nextPath}
-          title={dirEntry.nextTitle || dirEntry.nextPath}
+          title={`Next: ${dirEntry.nextTitle || dirEntry.nextPath}`}
         >
-          {' >> '}
+          {'next'}
         </a>
       ) : (
         ''

--- a/src/worker/src/components/blog-post-layout.tsx
+++ b/src/worker/src/components/blog-post-layout.tsx
@@ -1,10 +1,11 @@
 import { raw } from 'hono/html'
 import { type FC } from 'hono/jsx'
+import { Splash } from './splash'
+import { Menu } from './menu'
 
 export function formatDate(date: any) {
   if (typeof date === 'string') {
     date = new Date(date)
-    // console.log('parsed date', date)
   }
   if (!date || !(date instanceof Date)) return ''
   return new Intl.DateTimeFormat(undefined, {
@@ -12,17 +13,17 @@ export function formatDate(date: any) {
   }).format(date)
 }
 
-export const BlogPostLayout: FC = ({ children, page, dirEntry }) => {
-  // console.log('BlogPostLayout', dirPage)
+export const BlogPostLayout: FC = ({ page, site, dirEntry }) => {
   const longdate = [formatDate(page.attrs?.date)].filter(Boolean).join(' - ')
   return (
     <>
-      <p class="whitespace-nowrap overflow-hidden overflow-ellipsis">
-        <a href="/">Home</a> | <a href="/blog">Writings</a>
+      <Menu site={site} />
+      <Splash page={page} />
+      <p class="text-right gap-2 whitespace-nowrap overflow-hidden overflow-ellipsis">
         {dirEntry?.nextPath ? (
           <>
             <span class="text-gray-400">{' >> '}</span>
-            <a class="text-gray-400 hover:text-current" href={dirEntry.nextPath}>
+            <a class="text-gray-300 hover:text-current" href={dirEntry.nextPath}>
               {dirEntry.nextTitle || dirEntry.nextPath}
             </a>
           </>

--- a/src/worker/src/components/blog-post-layout.tsx
+++ b/src/worker/src/components/blog-post-layout.tsx
@@ -27,7 +27,7 @@ export const BlogPostLayout: FC = ({ page, site, dirEntry }) => {
           href={dirEntry.nextPath}
           title={`Next: ${dirEntry.nextTitle || dirEntry.nextPath}`}
         >
-          {'next'}
+          {'>>'}
         </a>
       ) : (
         ''

--- a/src/worker/src/components/blog-post-layout.tsx
+++ b/src/worker/src/components/blog-post-layout.tsx
@@ -19,19 +19,21 @@ export const BlogPostLayout: FC = ({ page, site, dirEntry }) => {
     <>
       <Menu site={site} />
       <Splash page={page} />
-      <p class="text-right gap-2 whitespace-nowrap overflow-hidden overflow-ellipsis">
+      <p class="text-gray-400 flex">
+        <span class="flex-grow">{longdate}</span>
         {dirEntry?.nextPath ? (
-          <>
-            <span class="text-gray-400">{' >> '}</span>
-            <a class="text-gray-300 hover:text-current" href={dirEntry.nextPath}>
-              {dirEntry.nextTitle || dirEntry.nextPath}
-            </a>
-          </>
-        ) : (
-          ''
-        )}
+        <a
+          class="text-gray-400 hover:text-current no-underline px-4"
+          href={dirEntry.nextPath}
+          title={dirEntry.nextTitle || dirEntry.nextPath}
+        >
+          {' >> '}
+        </a>
+      ) : (
+        ''
+      )}
+
       </p>
-      <p class="text-gray-400">{longdate}</p>
       {raw(page.html)}
     </>
   )

--- a/src/worker/src/components/default-layout.tsx
+++ b/src/worker/src/components/default-layout.tsx
@@ -2,11 +2,13 @@ import { raw } from 'hono/html'
 import { PropsWithChildren } from 'hono/jsx'
 import { Frontmatter, PageData } from '../types'
 import { Menu } from './menu'
+import { Splash } from './splash'
 
 export function DefaultLayout({ children, page, site }: PropsWithChildren<{ page: PageData, site: Frontmatter }>) {
   return (
     <>
       <Menu site={site} />
+      <Splash page={page} />
       {raw(page.html)}
       {children}
     </>

--- a/src/worker/src/components/html-page.tsx
+++ b/src/worker/src/components/html-page.tsx
@@ -75,16 +75,8 @@ export function renderJsx() {
           <script src="/js/htmx.min.js"></script>
           <script src="/js/image-enlarge.js"></script>
         </head>
-        <body class=" dark:bg-black">
+        <body class="dark:bg-black">
           <div class="prose dark:prose-invert font-mono max-w-[76ch] overflow-hidden md:mx-auto mx-3 mt-3 mb-9 marker:text-current">
-            {splashimage ? (
-              <img
-                id="splashimage"
-                src={splashimage}
-                alt="splash image"
-                class="h-[10.5rem] w-full object-cover cursor-default"
-              />
-            ) : null}
             {(componentMap[page?.attrs.layout as string] ?? componentMap['DefaultLayout'])({
               children,
               page,

--- a/src/worker/src/components/splash.tsx
+++ b/src/worker/src/components/splash.tsx
@@ -6,10 +6,10 @@ export const Splash: FC<{ page: PageData }> = ({ page }) => {
   if (!splashimage) return null
   return (
     <img
-      id="splashimage"
       src={splashimage}
-      alt="splash image"
       class="h-[10.5rem] w-full my-6 object-cover cursor-default"
+      alt="splash image"
+      role="presentation"
     />
   )
 }

--- a/src/worker/src/components/splash.tsx
+++ b/src/worker/src/components/splash.tsx
@@ -1,0 +1,15 @@
+import { FC } from 'hono/jsx'
+import { PageData } from '../types'
+
+export const Splash: FC<{ page: PageData }> = ({ page }) => {
+  const splashimage = page.attrs.splash?.image ?? page.attrs.splashimage
+  if (!splashimage) return null
+  return (
+    <img
+      id="splashimage"
+      src={splashimage}
+      alt="splash image"
+      class="h-[10.5rem] w-full my-6 object-cover cursor-default"
+    />
+  )
+}


### PR DESCRIPTION
Followup to 55477b75f827788f84c924100522481b4e4cc0c5 (Menu component)
Could use some icons to make the menu smaller on mobile, but this works.
 
![Screenshot 2024-10-29 at 10 52 37](https://github.com/user-attachments/assets/3d636de3-efe7-44f1-a998-a93e58375691)

![Screenshot 2024-10-29 at 10 53 57](https://github.com/user-attachments/assets/779c66d5-b00e-453a-bfd7-0db4ff95abec)
