### PR TITLE
Support chat for pages multi-level paths 

### DIFF
--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -19,7 +19,7 @@ function App() {
 
   const socket = usePartySocket({
     party: 'c-h-a-t-s', // kebab-cased CHATS binding name
-    room: window.location.pathname.replace('/', '_'),
+    room: window.location.pathname.replace(/\//g, '_'),
     onMessage: (evt) => {
       const message = JSON.parse(evt.data) as Message
       switch (message.type) {

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -19,6 +19,7 @@ function App() {
 
   const socket = usePartySocket({
     party: 'c-h-a-t-s', // kebab-cased CHATS binding name
+    // TODO: protect against paths with _
     room: window.location.pathname.replace(/\//g, '_'),
     onMessage: (evt) => {
       const message = JSON.parse(evt.data) as Message

--- a/src/dev/content/blog/index.md
+++ b/src/dev/content/blog/index.md
@@ -1,0 +1,6 @@
+---
+title: Presskit Blog
+layout: BlogListLayout
+sortby: date
+---
+# Writings

--- a/src/dev/content/blog/test-blog-post.md
+++ b/src/dev/content/blog/test-blog-post.md
@@ -1,0 +1,10 @@
+---
+title: "Test Blog Post"
+date: 2024-11-14
+layout: BlogPostLayout
+---
+
+This is a test blog post.
+
+It is about pets and about the weather and living in NYC.
+

--- a/src/worker/src/party.ts
+++ b/src/worker/src/party.ts
@@ -25,7 +25,7 @@ export class Party extends Server<Env> {
   }
 
   async onConnect(connection: Connection, ctx: ConnectionContext) {
-    const path = ctx.request.headers.get('x-partykit-room')?.replace('_', '/')
+    const path = ctx.request.headers.get('x-partykit-room')?.replace(/_/g, '/')
     if (path) {
       const cachedContent = await this.env.PAGE_CACHE.get(path)
       if (cachedContent !== null) {

--- a/src/worker/src/party.ts
+++ b/src/worker/src/party.ts
@@ -25,6 +25,7 @@ export class Party extends Server<Env> {
   }
 
   async onConnect(connection: Connection, ctx: ConnectionContext) {
+    // TODO: protect against paths with _
     const path = ctx.request.headers.get('x-partykit-room')?.replace(/_/g, '/')
     if (path) {
       const cachedContent = await this.env.PAGE_CACHE.get(path)


### PR DESCRIPTION
Fix the party room name to allow for multiple '/' substitutions.
This will allow chat on /blog/topic pages.
 
![Screenshot 2024-11-14 at 14 44 53](https://github.com/user-attachments/assets/72bece84-e02a-41b4-a91a-da50a6026348)
